### PR TITLE
Bugfix: excluded_announcements in session is a list not a set

### DIFF
--- a/announcements/templatetags/announcements_tags.py
+++ b/announcements/templatetags/announcements_tags.py
@@ -29,7 +29,8 @@ class AnnouncementsNode(template.Node):
             site_wide=True
         )
 
-        exclusions = request.session.get("excluded_announcements", set())
+        exclusions = request.session.get("excluded_announcements", [])
+        exclusions = set(exclusions)
         if request.user.is_authenticated():
             for dismissal in request.user.announcement_dismissals.all():
                 exclusions.add(dismissal.announcement.pk)


### PR DESCRIPTION
This was fixed by someone else already, but they missed the `announcements_tags.py` file