### PR TITLE
Remove use of deprecated django.conf.urls.patterns.

### DIFF
--- a/announcements/urls.py
+++ b/announcements/urls.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from announcements.views import detail, dismiss
 from announcements.views import CreateAnnouncementView, UpdateAnnouncementView
 from announcements.views import DeleteAnnouncementView, AnnouncementListView
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^$", AnnouncementListView.as_view(), name="announcements_list"),
     url(r"^announcement/create/$", CreateAnnouncementView.as_view(), name="announcements_create"),
     url(r"^announcement/(?P<pk>\d+)/$", detail, name="announcements_detail"),
@@ -14,4 +13,4 @@ urlpatterns = patterns(
         name="announcements_update"),
     url(r"^announcement/(?P<pk>\d+)/delete/$", DeleteAnnouncementView.as_view(),
         name="announcements_delete"),
-)
+]


### PR DESCRIPTION
Fixes a warning that happens when running with Django 1.9:

```
/venv/local/lib/python2.7/site-packages/announcements/urls.py:16: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  name="announcements_delete"),
```